### PR TITLE
fix: read OAuth token from Authorization header instead of query param

### DIFF
--- a/src/functions/auth-google.ts
+++ b/src/functions/auth-google.ts
@@ -23,8 +23,8 @@ export async function authGoogle(
 ): Promise<HttpResponseInit> {
   context.log(`Http function processed request for url "${request.url}"`);
 
-  // Get the access token from the query or the request body
-  const accessToken = request.query.get('access_token') || (await request.text());
+  // Get the access token from the Authorization header
+  const accessToken = request.headers.get('authorization')?.replace('Bearer ', '');
 
   try {
     // Fetch the user profile using the access token


### PR DESCRIPTION
## Summary
- Replaces `req.query.access_token` with `req.headers['authorization']?.replace('Bearer ', '')` in the `auth-google` function
- Fixes an OWASP vulnerability where the token was exposed in server logs, browser history, and HTTP Referer headers